### PR TITLE
fix(render): correct tile_builder_skips_clean_rows test for span-aware scanning

### DIFF
--- a/crates/ftui-render/src/diff.rs
+++ b/crates/ftui-render/src/diff.rs
@@ -2772,9 +2772,7 @@ mod tests {
         new.set_raw(3, 0, Cell::from_char('X'));
         new.set_raw(4, 10, Cell::from_char('Y'));
 
-        let dirty_rows = new.dirty_row_count().max(1);
         let total_cells = width as usize * height as usize;
-        let expected_skip_cells = dirty_rows * width as usize;
 
         let base = TileDiffConfig {
             enabled: true,
@@ -2798,9 +2796,21 @@ mod tests {
         let stats_full = tile_stats_for_config(&old, &new, config_full);
         let stats_skip = tile_stats_for_config(&old, &new, config_skip);
 
-        assert_eq!(stats_full.sat_build_cells, total_cells);
-        assert_eq!(stats_skip.sat_build_cells, expected_skip_cells);
-        assert!(stats_skip.sat_build_cells < stats_full.sat_build_cells);
+        // Span-aware scanning means sat_build_cells counts only span-covered
+        // cells, not full row widths.  The key invariant is that skip_clean_rows
+        // scans strictly fewer cells than the non-skip path.
+        assert!(
+            stats_full.sat_build_cells > 0 && stats_full.sat_build_cells <= total_cells,
+            "full scan cells {} should be >0 and <= total {}",
+            stats_full.sat_build_cells,
+            total_cells,
+        );
+        assert!(
+            stats_skip.sat_build_cells < stats_full.sat_build_cells,
+            "skip ({}) should scan fewer cells than full ({})",
+            stats_skip.sat_build_cells,
+            stats_full.sat_build_cells,
+        );
     }
 
     fn lcg_next(state: &mut u64) -> u64 {


### PR DESCRIPTION
## Summary

The `tile_builder_skips_clean_rows_when_enabled` test asserts exact `sat_build_cells` counts (12000 for full scan, 400 for skip). After the span-aware tile diff builder was introduced in `870d24f1`, these counts no longer hold — the builder scans only span-covered cells within each row, not full row widths.

**The test fails on current `main`:** `left: 11602, right: 12000`.

## Fix

Changed assertions from exact cell counts to the relative invariant that `skip_clean_rows` reduces scanning:
- `stats_full.sat_build_cells > 0 && <= total_cells`
- `stats_skip.sat_build_cells < stats_full.sat_build_cells`

The important property — that `skip_clean_rows` scans strictly fewer cells — is preserved. The exact cell counts are implementation details that change with optimization.

## Verification

- Test passes after fix
- 1802 other tests in ftui-render unaffected
- Zero logic changes — test-only fix